### PR TITLE
Arreglar parpadeo de idle/walk usando intención de movimiento (#135)

### DIFF
--- a/src/ecs/components/World/MovementComponent.hpp
+++ b/src/ecs/components/World/MovementComponent.hpp
@@ -7,6 +7,7 @@ extern "C" {
 struct MovementComponent {
     float speed;
     bool isMoving;
+    bool wantsMove;
 
     Vector2 startPos;
     Vector2 targetPos;
@@ -15,5 +16,11 @@ struct MovementComponent {
     float duration;
 
     MovementComponent(float spd = 150.0f)
-        : speed(spd), isMoving(false), startPos{0,0}, targetPos{0,0}, progress(0.0f), duration(0.12f) {}
+        : speed(spd),
+          isMoving(false),
+          wantsMove(false),
+          startPos{0,0},
+          targetPos{0,0},
+          progress(0.0f),
+          duration(0.12f) {}
 };

--- a/src/ecs/systems/PlayerSystems.cpp
+++ b/src/ecs/systems/PlayerSystems.cpp
@@ -15,8 +15,6 @@ void InputSystem(entt::registry &registry, const Map &map) {
         auto &playerState = view.get<PlayerStateComponent>(entity);
         auto &cheats = view.get<PlayerCheatComponent>(entity);
 
-        if (move.isMoving) continue;
-
         int dx = 0;
         int dy = 0;
 
@@ -25,7 +23,8 @@ void InputSystem(entt::registry &registry, const Map &map) {
         else if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT)) dx = -1;
         else if (IsKeyDown(KEY_D) || IsKeyDown(KEY_RIGHT)) dx = 1;
 
-        if (dx == 0 && dy == 0) continue;
+        move.wantsMove = (dx != 0 || dy != 0);
+        if (move.isMoving || !move.wantsMove) continue;
 
         if (dx > 0) sprite.flipX = false;
         else if (dx < 0) sprite.flipX = true;

--- a/src/ecs/systems/WorldSystems.cpp
+++ b/src/ecs/systems/WorldSystems.cpp
@@ -40,7 +40,7 @@ void AnimationSystem(entt::registry &registry, float deltaTime) {
         auto &move = view.get<MovementComponent>(entity);
         auto &anim = view.get<AnimationComponent>(entity);
 
-        bool wantWalk = move.isMoving;
+        bool wantWalk = move.isMoving || move.wantsMove;
         if (wantWalk != anim.isWalking) {
             anim.isWalking = wantWalk;
             sprite.texture = anim.isWalking ? anim.walkTexture : anim.idleTexture;


### PR DESCRIPTION
Añadimos wantsMove al MovementComponent y lo actualizamos desde el input para que la animación use la intención junto con isMoving. Así evitamos el cambio rápido idle/walk entre tiles y el flickering al mantener una tecla de movimiento.